### PR TITLE
fix: change Dependabot to weekly schedule for supply chain protection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,19 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: 'weekly'
     ignore:
       # Ignore Kubernetes dependencies to have full control on them.
       - dependency-name: "k8s.io/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: 'weekly'
   - package-ecosystem: "docker"
     directory: "/docker/dev"
     schedule:
-      interval: "daily"
+      interval: 'weekly'
   - package-ecosystem: "docker"
     directory: "/docker/prod"
     schedule:
-      interval: "daily"
+      interval: 'weekly'


### PR DESCRIPTION
## Summary
- Changes Dependabot schedule from `daily` to `weekly`

## Why
Supply chain protection. Dependabot lacks a `minimumReleaseAge` setting, so switching to weekly provides a buffer against auto-merging recently-published compromised packages. Weekly schedule ensures at least several days pass before packages are picked up.